### PR TITLE
Correção na cor amarela por falta de visibilidade

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,5 +8,5 @@
 
     <color name="red">#FF0000</color>
     <color name="green">#32CD32</color>
-    <color name="yellow">#FFFF00</color>
+    <color name="yellow">#FFD700</color>
 </resources>


### PR DESCRIPTION
## O que foi feito?

- A cor amarela escolhida anteriormente, para mostrar o resultado "SOBREPESO", não estava bem visivel, então foi feito a troca para um amarelo mais escuro

<img src ="https://github.com/user-attachments/assets/7ac3644a-c8b9-4b55-abf3-fda1547917a5" width =200/>
